### PR TITLE
Prevent abuse case, fix desynch bug, prevent unintentional adding of non-scene participants via web portal

### DIFF
--- a/plugins/txt/plugin/commands/txt_new_scene.rb
+++ b/plugins/txt/plugin/commands/txt_new_scene.rb
@@ -26,6 +26,11 @@ module AresMUSH
     end
 
     def handle
+      # Is the texter approved?
+      if !enactor.is_approved?
+        client.emit_failure t('txt.newbies_cant_send_txts')
+        return
+      end
 
       self.names.each do |name|
         result = Character.named(name)

--- a/plugins/txt/plugin/commands/txt_send_cmd.rb
+++ b/plugins/txt/plugin/commands/txt_send_cmd.rb
@@ -52,6 +52,12 @@ module AresMUSH
 
 
         def handle
+          # Is the texter approved?
+          if !enactor.is_approved?
+            client.emit_failure t('txt.newbies_cant_send_txts')
+            return
+          end
+          
           # Is scene real and can you text to it?
           if self.scene_id
             scene = Scene[self.scene_id]
@@ -158,6 +164,13 @@ module AresMUSH
 
           enactor.update(txt_last: list_arg(recipient_names))
           enactor.update(txt_scene: self.scene_id)
+          
+          # Update txt_last_scene as well. This prevents the scenario of:
+          # 1) txt Alice=message
+          # 2) txt/newscene Brandon=message
+          # 3) (webportal, in the new scene:) hello
+          # Message goes to Alice and adds Alice to scene, despite Alice not being last texted.
+          enactor.update(txt_last_scene: list_arg(recipient_names))
 
       end
       def log_command

--- a/plugins/txt/plugin/locales/locale_en.yml
+++ b/plugins/txt/plugin/locales/locale_en.yml
@@ -33,3 +33,5 @@ en:
       incorrect_format: "That's not the correct format. Please use `name(s)=message`"
 
       txt_new_scene_target_missing: "Please specify a target and message. Ex: txt/newscene Name=Message"
+
+      character_not_already_part_of_scene: "At least one recipient isn't in this scene! Please use `name(s)=message` to add more people."

--- a/plugins/txt/plugin/locales/locale_en.yml
+++ b/plugins/txt/plugin/locales/locale_en.yml
@@ -34,5 +34,5 @@ en:
 
       txt_new_scene_target_missing: "Please specify a target and message. Ex: txt/newscene Name=Message"
 
-      character_not_already_part_of_scene: "At least one recipient isn't in this scene! Please use `name(s)=message` to add more people."
+      character_not_already_part_of_scene: "%{recipient} isn't in this scene yet. Please use `%{recipients}=message` if you want them added."
       newbies_cant_send_txts: "You must first be approved before you can send in-character text messages."

--- a/plugins/txt/plugin/locales/locale_en.yml
+++ b/plugins/txt/plugin/locales/locale_en.yml
@@ -35,3 +35,4 @@ en:
       txt_new_scene_target_missing: "Please specify a target and message. Ex: txt/newscene Name=Message"
 
       character_not_already_part_of_scene: "At least one recipient isn't in this scene! Please use `name(s)=message` to add more people."
+      newbies_cant_send_txts: "You must first be approved before you can send in-character text messages."

--- a/plugins/txt/plugin/txt.rb
+++ b/plugins/txt/plugin/txt.rb
@@ -14,7 +14,7 @@ module AresMUSH
         case cmd.root
         when "txt"
           case cmd.switch
-          when "color"
+          when "color", "colour"
             return TxtColorCmd
           when "newscene"
             return TxtNewSceneCmd

--- a/plugins/txt/plugin/txt.rb
+++ b/plugins/txt/plugin/txt.rb
@@ -14,7 +14,7 @@ module AresMUSH
         case cmd.root
         when "txt"
           case cmd.switch
-          when "color", "colour"
+          when "color"
             return TxtColorCmd
           when "newscene"
             return TxtNewSceneCmd

--- a/plugins/txt/plugin/web/add_txt_handler.rb
+++ b/plugins/txt/plugin/web/add_txt_handler.rb
@@ -91,7 +91,10 @@ module AresMUSH
                         can_txt_scene = Scenes.can_edit_scene?(char, scene)
                         if (!can_txt_scene)
                             # r_l_i_f_q means the texter deliberately added them. If false, it's an implicit add.
-                            if (recipients_list_is_fully_qualified)
+                            if (!recipients_list_is_fully_qualified)
+                                return { error: t('txt.character_not_already_part_of_scene',
+                                :recipients => recipient_names ) }
+                            else
                                 Scenes.add_to_scene(scene, t('txt.recipient_added_to_scene',
                                 :name => char.name ),
                                 enactor, nil, true )
@@ -106,9 +109,6 @@ module AresMUSH
                                 if (!scene.watchers.include?(char))
                                   scene.watchers.add char
                                 end
-                            else
-                                return { error: t('txt.character_not_already_part_of_scene',
-                                :recipients => recipient_names ) }
                             end
                         end
                     end

--- a/plugins/txt/plugin/web/add_txt_handler.rb
+++ b/plugins/txt/plugin/web/add_txt_handler.rb
@@ -93,6 +93,7 @@ module AresMUSH
                             # r_l_i_f_q means the texter deliberately added them. If false, it's an implicit add.
                             if (!recipients_list_is_fully_qualified)
                                 return { error: t('txt.character_not_already_part_of_scene',
+                                :recipient => char.name,
                                 :recipients => recipient_names ) }
                             end
                             

--- a/plugins/txt/plugin/web/add_txt_handler.rb
+++ b/plugins/txt/plugin/web/add_txt_handler.rb
@@ -94,21 +94,21 @@ module AresMUSH
                             if (!recipients_list_is_fully_qualified)
                                 return { error: t('txt.character_not_already_part_of_scene',
                                 :recipients => recipient_names ) }
-                            else
-                                Scenes.add_to_scene(scene, t('txt.recipient_added_to_scene',
-                                :name => char.name ),
-                                enactor, nil, true )
+                            end
+                            
+                            Scenes.add_to_scene(scene, t('txt.recipient_added_to_scene',
+                            :name => char.name ),
+                            enactor, nil, true )
 
-                                Rooms.emit_ooc_to_room scene_room,t('txt.recipient_added_to_scene',
-                                :name => char.name )
+                            Rooms.emit_ooc_to_room scene_room,t('txt.recipient_added_to_scene',
+                            :name => char.name )
 
-                                if (!scene.participants.include?(char))
-                                  scene.participants.add char
-                                end
+                            if (!scene.participants.include?(char))
+                              scene.participants.add char
+                            end
 
-                                if (!scene.watchers.include?(char))
-                                  scene.watchers.add char
-                                end
+                            if (!scene.watchers.include?(char))
+                              scene.watchers.add char
                             end
                         end
                     end

--- a/plugins/txt/readme.md
+++ b/plugins/txt/readme.md
@@ -1,7 +1,7 @@
 # Text System
 
 ## Credit
-This plugin was originally coded by skew @ Ares Central, with a few updates and packaging by Tat @ Ares Central, and an unintentional-text prevention mechanism from Ell @ Ares Central.
+This plugin was originally coded by skew @ Ares Central, with a few updates and packaging by Tat @ Ares Central, and bugfixes and an unintentional-text prevention mechanism from Ell @ Ares Central.
 
 ## Overview
 

--- a/plugins/txt/readme.md
+++ b/plugins/txt/readme.md
@@ -1,7 +1,7 @@
 # Text System
 
 ## Credit
-This plugin was originally coded by skew @ Ares Central, with a few updates and packaging by Tat @ Ares Central.
+This plugin was originally coded by skew @ Ares Central, with a few updates and packaging by Tat @ Ares Central, and an unintentional-text prevention mechanism from Ell @ Ares Central.
 
 ## Overview
 


### PR DESCRIPTION
#### Prevented unapproved characters from sending text messages.

Previously there were no checks to see if characters were approved before texting, which enabled the txt plugin to be abused to spam characters ICly. This is no longer possible.

#### Fixed a bug that caused de-synchronization between client and web portal last-texted states in certain scenarios.

This solves the following web portal texting issue:

1) `txt Alice/122=message`
2) `txt/newscene Brandon=message` (scene 123 is created)
3) (in the webportal, in scene 123) `hello`
- Message goes to Alice and adds Alice to scene 123, despite Alice not being last texted.

#### Prevented unintentional addition of non-scene participants to scene via web portal text messages.

This solves the following web portal texting issue:

Assuming the last person you texted was A:

1) Send a text in scene 1 (members: you, A) without specifying the recipient.
- Result: Your message is sent to A (the other participant in your scene).

2) Switch to scene 2 (members: you, B) and send a text without specifying the recipient
- Result: Your message is sent to A (not a member of the scene) and A is added to the scene.

With this change, the second case will instead return an error message to the web portal and require that you explicitly make them a member of the scene first. It recommends that you add them to the scene with `name[ name...]=message` to send the message seamlessly, but any method of including them will work.